### PR TITLE
Bug fix for max people num filter

### DIFF
--- a/utils/group.py
+++ b/utils/group.py
@@ -43,8 +43,6 @@ def match_by_tag(inp, params, pad=False):
             actualTags_key = actualTags
             actualTags = [np.mean(dic2[i], axis = 0) for i in actualTags]
 
-            if params.ignore_too_much and len(actualTags) == params.max_num_people:
-                continue
             diff = ((joints[:, None, 3:] - np.array(actualTags)[None, :, :])**2).mean(axis = 2) ** 0.5
             if diff.shape[0]==0:
                 continue
@@ -63,6 +61,8 @@ def match_by_tag(inp, params, pad=False):
                     dic[actualTags_key[col]][ptIdx] = joints[row]
                     dic2[actualTags_key[col]].append(tags[row])
                 else:
+                    if params.ignore_too_much and len(actualTags) == params.max_num_people:
+                        continue
                     key = tags[row][0]
                     dic.setdefault(key, np.copy(default_))[ptIdx] = joints[row]
                     dic2[key] = [tags[row]]


### PR DESCRIPTION
# Problem
I found the some images contains more than max_num_people defined in the [task](https://github.com/umich-vl/pose-ae-train/blob/master/task/pose.py#L39). 

# Cause
Firstly, although [function calc](https://github.com/umich-vl/pose-ae-train/blob/master/utils/group.py#L116) only extracts topk activations from each joint heatmap, these activation need to be [matched by tags](https://github.com/umich-vl/pose-ae-train/blob/master/utils/group.py#L22) to get the final predicted people number. 

However, people number will be larger than activations in single joint heatmap. 
For example, nose heatmap has 27 activations higher than detection threshold, while eye heatmap has 28 activations higher than detection threshold. If only 20 of them can be matched (they only match each other when their tags are closed enough), 7 activations are remained in nose heatmap, 8 in eye heatmap. So we got 20+7+8=35 persons in eye iterations as `dic` and `dic2` [increase](https://github.com/umich-vl/pose-ae-train/blob/master/utils/group.py#L67).

# Solution
I notice that this [line](https://github.com/umich-vl/pose-ae-train/blob/master/utils/group.py#L46) try to  ignore joints matching after tags reach max_num_people. But it's a mistake to use `len(actualTags) == params.max_num_people` because `len(actualTags)` may increase by more than 1 in one joint iteration, 27->35 as the example above.

What's more, when there are lots of people in the images, this condition judgement will miss all the keypoints in lower half of body for all people. So I think that's not a good idea to ignore  joints matching after tags reach max_num_people, by simply modifying  `len(actualTags) == params.max_num_people` to  `len(actualTags) >= params.max_num_people` or something.  By the way, this modification will still produce some results with people numbers slightly larger than max_num_people.

As a result , I suggest to place this statement before we [change `dic` and `dic2`](https://github.com/umich-vl/pose-ae-train/blob/master/utils/group.py#L66) to increase persons.

```python
if row<diff2.shape[0] and col < diff2.shape[1] and diff2[row][col] < params.tag_threshold:
    dic[actualTags_key[col]][ptIdx] = joints[row]
    dic2[actualTags_key[col]].append(tags[row])
else:
    if params.ignore_too_much and len(actualTags) == params.max_num_people:
        continue
    key = tags[row][0]
    dic.setdefault(key, np.copy(default_))[ptIdx] = joints[row]
    dic2[key] = [tags[row]]
```

So I create a PR to fix this problem.